### PR TITLE
Fixed links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.15.0"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 
 description = """Command line interface for Tantivy, a search engine library."""
-documentation = "https://github.com/tantivy-search/tantivy-cli"
-homepage = "https://github.com/tantivy-search/tantivy-cli"
-repository = "https://github.com/tantivy-search/tantivy-cli"
+documentation = "https://github.com/quickwit-inc/tantivy-cli"
+homepage = "https://github.com/quickwit-inc/tantivy-cli"
+repository = "https://github.com/quickwit-inc/tantivy-cli"
 
 readme = "README.md"
 keywords = ["search", "information", "retrieval"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![beacon for google analytics](https://ga-beacon.appspot.com/UA-88834340-1/tantivy-cli/README)
 
 
-`tantivy-cli` is the project hosting the command line interface for [tantivy](https://github.com/tantivy-search/tantivy), a search engine project.
+`tantivy-cli` is the project hosting the command line interface for [tantivy](https://github.com/quickwit-inc/tantivy), a search engine project.
 
 
 # Tutorial: Indexing Wikipedia with Tantivy CLI


### PR DESCRIPTION
fixed repo links
@fulmicoton  Are we going to update the Github page as well ?

`https://tantivy-search.github.io/tantivy/tantivy/schema/index.html`